### PR TITLE
Callback

### DIFF
--- a/nipype2/engine/node.py
+++ b/nipype2/engine/node.py
@@ -156,7 +156,7 @@ class Node(object):
         for key_out in list(output.keys()):
             with open(os.path.join(self.nodedir, dir_nm_el, key_out+".txt"), "w") as fout:
                 fout.write(str(output[key_out]))
-        return (i, ind, self) # added this for callback
+        return (i, ind, self.name) # added this for callback
 
 
     def preparing_node(self):

--- a/nipype2/engine/node.py
+++ b/nipype2/engine/node.py
@@ -79,11 +79,10 @@ class Node(object):
         self._hierarchy = None
         self.plugin = plugin
         self._input_order_map = {}
-        self._history = {} #tracking which node should give input
         self.sufficient = True
         self._result = {}
         self.needed_outputs = []
-        self._send_outputs = []
+        self.sending_output = [] # what should be send to another nodes
         if self._reducer is None:
             self._out_nm = self._interface._output_nm
         else:
@@ -157,6 +156,7 @@ class Node(object):
         for key_out in list(output.keys()):
             with open(os.path.join(self.nodedir, dir_nm_el, key_out+".txt"), "w") as fout:
                 fout.write(str(output[key_out]))
+        return (i, ind, self) # added this for callback
 
 
     def preparing_node(self):

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -118,24 +118,24 @@ class Submiter(object):
 
 
 
-                    # not beeing used now (probably will be removed)
-    def _waiting_for_output(self):
-        # checking which node is ready to go. should be done my callback (TODO)
-        while self.node_line:
-            logger.debug("Submitter, node_line: {}".format(self.node_line))
-            for i, node in enumerate(self.node_line):
-                for (out_node, out_var, inp) in node.needed_outputs:
-                    # TODO this works only because there is no mapper!
-                    try:
-                        file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
-                    except(IndexError):
-                        file_output = None
-                    if file_output and os.path.isfile(file_output):
-                        with open(file_output) as f:
-                            node.inputs.update({inp: eval(f.readline())})
-                        node.needed_outputs.remove((out_node, out_var, inp))
-                if not node.needed_outputs:
-                    self.node_line.remove(node)
-                    node.sufficient = True
-                    self.submit_work(node)
-            time.sleep(3)
+    # not beeing used now (probably will be removed)
+    # def _waiting_for_output(self):
+    #     # checking which node is ready to go. should be done my callback (TODO)
+    #     while self.node_line:
+    #         logger.debug("Submitter, node_line: {}".format(self.node_line))
+    #         for i, node in enumerate(self.node_line):
+    #             for (out_node, out_var, inp) in node.needed_outputs:
+    #                 # TODO this works only because there is no mapper!
+    #                 try:
+    #                     file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
+    #                 except(IndexError):
+    #                     file_output = None
+    #                 if file_output and os.path.isfile(file_output):
+    #                     with open(file_output) as f:
+    #                         node.inputs.update({inp: eval(f.readline())})
+    #                     node.needed_outputs.remove((out_node, out_var, inp))
+    #             if not node.needed_outputs:
+    #                 self.node_line.remove(node)
+    #                 node.sufficient = True
+    #                 self.submit_work(node)
+    #         time.sleep(3)

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -19,19 +19,24 @@ logger = logging.getLogger('workflow')
 class Submiter(object):
     def __init__(self, graph, plugin):
         self.graph = graph
+        # i only use it for callback (had problem when I was passing node
+        # instead of node.name - `self.node_line.remove(to_node)` gives an error)
+        self.graph_names = dict([(node.name, node) for node in self.graph])
         self.plugin = plugin
         self.node_line = []
         self.done = queue.Queue()
         if self.plugin == "mp":
             self.worker = MpWorker(done=self.done)
         logger.debug('Initialize Submitter, graph: {}'.format(graph))
-
+        self._count_subm = 0
+        self._count_done = 0
 
 
     def run_workflow(self):
         for (i_n, node) in enumerate(self.graph):
             # checking if a node has all input (doesnt have to wait for others)
             if node.sufficient:
+                self._count_subm += 1
                 self.submit_work(node)
             # if its not, its been added to a line
             else:
@@ -43,51 +48,30 @@ class Submiter(object):
             try:
                 el_done = self.done.get(timeout=1)
                 logger.debug("Submitter, el from self.done: {}".format(el_done))
+                self._count_done += 1
                 time.sleep(2)
                 self.connecting_output(el_done)
             except queue.Empty:
                 time.sleep(3)
             logger.debug("Submitter, node_line AFTER trying to get new output: {}".format(self.node_line))
 
-
-        # final reading of the results, this will be removed in the final version (TODO)
-        # combining all results from specifics nodes together (for all state elements)
-        time.sleep(3)
-        for (i_n, node) in enumerate(self.graph):
-            for key_out in node._out_nm:
-                node._result[key_out] = []
-                if node._inputs:
-                    files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
-                    for file in files:
-                        st_el = file.split(os.sep)[-2].split("_")
-                        st_dict =  collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
-                                                                for el in st_el])
-                        with open(file) as fout:
-                            node._result[key_out].append((st_dict, eval(fout.readline())))
-                # for nodes without input
-                else:
-                    files = [name for name in glob.glob("{}/{}.txt".format(node.nodedir, key_out))]
-                    with open(files[0]) as fout:
-                        node._result[key_out].append(({}, eval(fout.readline())))
+        self._collecting_results()
 
 
     def connecting_output(self, el_out):
-        from_node = el_out[2]
+        from_node = self.graph_names[el_out[2]]#el_out[2]
         for (from_socket, to_node, to_socket) in from_node.sending_output:
             if (from_node, from_socket, to_socket) in to_node.needed_outputs:
                 # TODO this works only because there is no mapper!
-                #pdb.set_trace()
-                print("FILE OUTPUT", [name for name in glob.glob("{}/*/{}.txt".format(from_node.nodedir, from_socket))])
                 file_output = [name for name in glob.glob("{}/*/{}.txt".format(from_node.nodedir, from_socket))][0]
                 with open(file_output) as f:
                     to_node.inputs.update({to_socket: eval(f.readline())})
                 to_node.needed_outputs.remove((from_node, from_socket, to_socket))
 
                 if not to_node.needed_outputs:
-                    print("TO NODE", to_node)
-                    pdb.set_trace()
                     self.node_line.remove(to_node)
                     to_node.sufficient = True
+                    self._count_subm += 1
                     self.submit_work(to_node)
             else:
                 raise Exception("something wrong with connections")
@@ -98,13 +82,43 @@ class Submiter(object):
                                         inp_ord_map=node._input_order_map)
         for (i, ind) in enumerate(itertools.product(*node.node_states._all_elements)):
             logger.debug("SUBMIT WORKER, node: {}, ind: {}".format(node, ind))
-            self.worker.run_el(node.run_interface_el, (i, ind), node)
+            self.worker.run_el(node.run_interface_el, (i, ind))
+
+
+    def _collecting_results(self):
+        """
+        final reading of the results, this will be removed in the final version (TODO)
+         combining all results from specifics nodes together (for all state elements)
+        """
+        # have to check if all results are ready
+        while self._count_done < self._count_subm:
+            try:
+                self.done.get(timeout=1)
+                self._count_done += 1
+            except queue.Empty:
+                time.sleep(3)
+
+        for (i_n, node) in enumerate(self.graph):
+            for key_out in node._out_nm:
+                node._result[key_out] = []
+                if node._inputs:
+                    files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
+                    for file in files:
+                        st_el = file.split(os.sep)[-2].split("_")
+                        st_dict = collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
+                                                           for el in st_el])
+                        with open(file) as fout:
+                            node._result[key_out].append((st_dict, eval(fout.readline())))
+                # for nodes without input
+                else:
+                    files = [name for name in glob.glob("{}/{}.txt".format(node.nodedir, key_out))]
+                    with open(files[0]) as fout:
+                        node._result[key_out].append(({}, eval(fout.readline())))
 
 
 
 
-
-# not beeing used now (probably will be removed)
+                    # not beeing used now (probably will be removed)
     def _waiting_for_output(self):
         # checking which node is ready to go. should be done my callback (TODO)
         while self.node_line:

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -21,8 +21,9 @@ class Submiter(object):
         self.graph = graph
         self.plugin = plugin
         self.node_line = []
+        self.done = queue.Queue()
         if self.plugin == "mp":
-            self.worker = MpWorker()
+            self.worker = MpWorker(done=self.done)
         logger.debug('Initialize Submitter, graph: {}'.format(graph))
 
 
@@ -31,30 +32,23 @@ class Submiter(object):
         for (i_n, node) in enumerate(self.graph):
             # checking if a node has all input (doesnt have to wait for others)
             if node.sufficient:
-                self.submit_work(node, i_n)
+                self.submit_work(node)
             # if its not, its been added to a line
             else:
-                self.node_line.append((node, i_n))
+                self.node_line.append(node)
 
-        # checking which node is ready to go. should be done my callback (TODO)
+        # TODO: should add an extra condition to not stay here forever
         while self.node_line:
-            logger.debug("Submitter, node_line: {}".format(self.node_line))
-            for i, (node, i_n) in enumerate(self.node_line):
-                for (out_node, out_var, inp) in node.needed_outputs:
-                    # TODO this works only because there is no mapper!
-                    try:
-                        file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
-                    except(IndexError):
-                        file_output = None
-                    if file_output and os.path.isfile(file_output):
-                        with open(file_output) as f:
-                            node.inputs.update({inp: eval(f.readline())})
-                        node.needed_outputs.remove((out_node, out_var, inp))
-                if not node.needed_outputs:
-                    self.node_line.remove((node, i_n))
-                    node.sufficient = True
-                    self.submit_work(node, i_n)
-            time.sleep(3)
+            logger.debug("Submitter, node_line BEFORE trying to get new output: {}".format(self.node_line))
+            try:
+                el_done = self.done.get(timeout=1)
+                logger.debug("Submitter, el from self.done: {}".format(el_done))
+                time.sleep(2)
+                self.connecting_output(el_done)
+            except queue.Empty:
+                time.sleep(3)
+            logger.debug("Submitter, node_line AFTER trying to get new output: {}".format(self.node_line))
+
 
         # final reading of the results, this will be removed in the final version (TODO)
         # combining all results from specifics nodes together (for all state elements)
@@ -77,11 +71,57 @@ class Submiter(object):
                         node._result[key_out].append(({}, eval(fout.readline())))
 
 
-    def submit_work(self, node, i_n):
+    def connecting_output(self, el_out):
+        from_node = el_out[2]
+        for (from_socket, to_node, to_socket) in from_node.sending_output:
+            if (from_node, from_socket, to_socket) in to_node.needed_outputs:
+                # TODO this works only because there is no mapper!
+                #pdb.set_trace()
+                print("FILE OUTPUT", [name for name in glob.glob("{}/*/{}.txt".format(from_node.nodedir, from_socket))])
+                file_output = [name for name in glob.glob("{}/*/{}.txt".format(from_node.nodedir, from_socket))][0]
+                with open(file_output) as f:
+                    to_node.inputs.update({to_socket: eval(f.readline())})
+                to_node.needed_outputs.remove((from_node, from_socket, to_socket))
+
+                if not to_node.needed_outputs:
+                    print("TO NODE", to_node)
+                    pdb.set_trace()
+                    self.node_line.remove(to_node)
+                    to_node.sufficient = True
+                    self.submit_work(to_node)
+            else:
+                raise Exception("something wrong with connections")
+
+
+    def submit_work(self, node):
         node.node_states_inputs = State(state_inputs=node._inputs, mapper=node._mapper,
                                         inp_ord_map=node._input_order_map)
         for (i, ind) in enumerate(itertools.product(*node.node_states._all_elements)):
             logger.debug("SUBMIT WORKER, node: {}, ind: {}".format(node, ind))
-            self.worker.run_el(node.run_interface_el, (i, ind))
+            self.worker.run_el(node.run_interface_el, (i, ind), node)
 
 
+
+
+
+# not beeing used now (probably will be removed)
+    def _waiting_for_output(self):
+        # checking which node is ready to go. should be done my callback (TODO)
+        while self.node_line:
+            logger.debug("Submitter, node_line: {}".format(self.node_line))
+            for i, node in enumerate(self.node_line):
+                for (out_node, out_var, inp) in node.needed_outputs:
+                    # TODO this works only because there is no mapper!
+                    try:
+                        file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
+                    except(IndexError):
+                        file_output = None
+                    if file_output and os.path.isfile(file_output):
+                        with open(file_output) as f:
+                            node.inputs.update({inp: eval(f.readline())})
+                        node.needed_outputs.remove((out_node, out_var, inp))
+                if not node.needed_outputs:
+                    self.node_line.remove(node)
+                    node.sufficient = True
+                    self.submit_work(node)
+            time.sleep(3)

--- a/nipype2/engine/tests/test_workflow_basic.py
+++ b/nipype2/engine/tests/test_workflow_basic.py
@@ -11,9 +11,9 @@ config.enable_debug_mode()
 logging.update_logging(config)
 
 def funA(a):
-    print("AAA BEFORE WAITITIN")
-    time.sleep(7)
-    print("AAA AFTER WAITITIN")
+    print("A Before Waiting")
+    time.sleep(5)
+    print("A After Waiting")
     return a**2
 
 def funB(b):
@@ -41,9 +41,9 @@ def test_workflow_basic_1():
               interface=Function_Interface(funB, ["out"]),
               name="nB", plugin="mp")
 
-    wf = Workflow(nodes=[nA, nB], name="workflow_1", workingdir="test1")
+    wf = Workflow(nodes=[nA, nB], name="workflow_1", workingdir="test_1")
     wf.run()
-    pdb.set_trace()
+
     assert nA.result["out"][0][0] == {"a":5}
     assert nA.result["out"][0][1] == 25
 
@@ -62,7 +62,7 @@ def test_workflow_basic_2():
     nC = Node(interface=Function_Interface(funC, ["out"]),
               name="nC", plugin="mp")
 
-    wf = Workflow(nodes=[nA, nB, nC], name="workflow_2", workingdir="test2")
+    wf = Workflow(nodes=[nA, nB, nC], name="workflow_2", workingdir="test_2")
     wf.connect(nA, "out", nC, "c")
     wf.run()
 
@@ -95,7 +95,7 @@ def test_workflow_basic_3():
 
 
 
-    wf = Workflow(nodes=[nA, nB, nC, nD, nE, nF], name="workflow_3", workingdir="test3")
+    wf = Workflow(nodes=[nA, nB, nC, nD, nE, nF], name="workflow_3", workingdir="test_3")
     wf.connect(nA, "out", nC, "c")
     wf.connect(nA, "out", nD, "d1")
     wf.connect(nB, "out", nD, "d2")

--- a/nipype2/engine/tests/test_workflow_basic.py
+++ b/nipype2/engine/tests/test_workflow_basic.py
@@ -11,7 +11,9 @@ config.enable_debug_mode()
 logging.update_logging(config)
 
 def funA(a):
-    #time.sleep(5)
+    print("AAA BEFORE WAITITIN")
+    time.sleep(7)
+    print("AAA AFTER WAITITIN")
     return a**2
 
 def funB(b):
@@ -41,7 +43,7 @@ def test_workflow_basic_1():
 
     wf = Workflow(nodes=[nA, nB], name="workflow_1", workingdir="test1")
     wf.run()
-
+    pdb.set_trace()
     assert nA.result["out"][0][0] == {"a":5}
     assert nA.result["out"][0][1] == 25
 

--- a/nipype2/engine/workers.py
+++ b/nipype2/engine/workers.py
@@ -15,13 +15,15 @@ from .. import config, logging
 logger = logging.getLogger('workflow')
 
 class MpWorker(object):
-    def __init__(self, nr_proc=4): #should be none
+    def __init__(self, done, nr_proc=4): #should be none
         self.nr_proc = nr_proc
+        self.done = done
         self.pool = mp.Pool(processes=self.nr_proc)
         logger.debug('Initialize Worker')
 
 
-    def run_el(self, interface, inp):
-        self.pool.apply_async(interface, (inp[0], inp[1]))
+    def run_el(self, interface, inp, node):
+        print("CALLING ", node)
+        self.pool.apply_async(interface, (inp[0], inp[1]), callback=self.done.put)#((inp, node)))
 
 

--- a/nipype2/engine/workers.py
+++ b/nipype2/engine/workers.py
@@ -14,6 +14,7 @@ import itertools
 from .. import config, logging
 logger = logging.getLogger('workflow')
 
+
 class MpWorker(object):
     def __init__(self, done, nr_proc=4): #should be none
         self.nr_proc = nr_proc
@@ -22,8 +23,8 @@ class MpWorker(object):
         logger.debug('Initialize Worker')
 
 
-    def run_el(self, interface, inp, node):
-        print("CALLING ", node)
-        self.pool.apply_async(interface, (inp[0], inp[1]), callback=self.done.put)#((inp, node)))
+    def run_el(self, interface, inp):
+        # dj NOTE: if I return (inp, node) as callback, then i have it right away (before node ends)
+        self.pool.apply_async(interface, (inp[0], inp[1]), callback=self.done.put)
 
 

--- a/nipype2/engine/workflow.py
+++ b/nipype2/engine/workflow.py
@@ -29,8 +29,10 @@ class Workflow(object):
         else:
             self._nodes = []
         self.connected_var = {}
+        #self.connected_var_reverse = {}
         for nn in self._nodes:
             self.connected_var[nn] = {}
+        #    self.connected_var_reverse[nn] = {}
         logger.debug('Initialize workflow')
         self.workingdir = workingdir
         self.plugin = plugin
@@ -47,6 +49,7 @@ class Workflow(object):
         self.graph.add_nodes_from(nodes)
         for nn in nodes:
             self.connected_var[nn] = {}
+            #self.connected_var_reverse[nn] = {}
 
 
     def connect(self, from_node, from_socket, to_node, to_socket):
@@ -54,6 +57,8 @@ class Workflow(object):
         if not to_node in self.nodes:
             self.add_nodes(to_node)
         self.connected_var[to_node][to_socket] = (from_node, from_socket)
+        from_node.sending_output.append((from_socket, to_node, to_socket))
+        #self.connected_var_reverse[from_node][from_socket] = (to_node, to_socket)
         logger.debug('connecting {} and {}'.format(from_node, to_node))
 
 
@@ -67,10 +72,7 @@ class Workflow(object):
                 for inp, (out_node, out_var) in self.connected_var[nn].items():
                     nn.sufficient = False #it has some history (doesnt have to be in the loop)
                     nn._state_inputs.update(out_node._state_inputs)
-                    for key in list(out_node._state_inputs.keys()):
-                        nn._history[key] = (out_node, inp) # not sure if i will need inp
                     nn.needed_outputs.append((out_node, out_var, inp))
-                    out_node._send_outputs.append((out_var, nn, inp))
 #TMP: no mapper for now
                     # #pdb.set_trace()
                     # #if there is no mapper provided, i'm assuming that mapper is taken from the previous node

--- a/nipype2/engine/workflow.py
+++ b/nipype2/engine/workflow.py
@@ -29,10 +29,8 @@ class Workflow(object):
         else:
             self._nodes = []
         self.connected_var = {}
-        #self.connected_var_reverse = {}
         for nn in self._nodes:
             self.connected_var[nn] = {}
-        #    self.connected_var_reverse[nn] = {}
         logger.debug('Initialize workflow')
         self.workingdir = workingdir
         self.plugin = plugin
@@ -49,7 +47,6 @@ class Workflow(object):
         self.graph.add_nodes_from(nodes)
         for nn in nodes:
             self.connected_var[nn] = {}
-            #self.connected_var_reverse[nn] = {}
 
 
     def connect(self, from_node, from_socket, to_node, to_socket):
@@ -58,7 +55,6 @@ class Workflow(object):
             self.add_nodes(to_node)
         self.connected_var[to_node][to_socket] = (from_node, from_socket)
         from_node.sending_output.append((from_socket, to_node, to_socket))
-        #self.connected_var_reverse[from_node][from_socket] = (to_node, to_socket)
         logger.debug('connecting {} and {}'.format(from_node, to_node))
 
 


### PR DESCRIPTION
using `callback` in `apply_async`: simple version that put something to queue and the submitter is trying to get an  element until everything is done (so no triggering).

had problem that when I tried to pass arguments of `MpWorker.run_el` to `callback`, multiproc was adding elements to the queue right away (without waiting for interface to finish), so decided to add `return` to `Node.run_interface_el` 