### PR TITLE
Removing callback

### DIFF
--- a/nipype2/engine/node.py
+++ b/nipype2/engine/node.py
@@ -200,7 +200,6 @@ class Node(object):
                                        if i in list(from_node._state_inputs.keys())])
             file_from = os.path.join(from_node.nodedir, dir_nm_el_from, from_socket+".txt")
             with open(file_from) as f:
-                #print("RUN INTERFACE LOOP FILE", f.readline())
                 inputs_dict[to_socket] = eval(f.readline())
 
         self._interface.run(inputs_dict)

--- a/nipype2/engine/node.py
+++ b/nipype2/engine/node.py
@@ -156,7 +156,6 @@ class Node(object):
         for key_out in list(output.keys()):
             with open(os.path.join(self.nodedir, dir_nm_el, key_out+".txt"), "w") as fout:
                 fout.write(str(output[key_out]))
-        return (i, ind, self.name) # added this for callback
 
 
     def preparing_node(self):

--- a/nipype2/engine/state.py
+++ b/nipype2/engine/state.py
@@ -76,9 +76,6 @@ class State(object):
 
 
     def state_values(self, ind):
-        #print("IND", ind)
-        #pdb.set_trace()
-
 
         from collections import OrderedDict
         if len(ind) > self._ndim:

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -30,18 +30,26 @@ class Submiter(object):
 
     def run_workflow(self):
         for (i_n, node) in enumerate(self.graph):
-            # checking if a node has all input (doesnt have to wait for others)
+            # submitting all the nodes who are self sufficient (self.graph is already sorted)
             if node.sufficient:
                 self.submit_work(node)
             # if its not, its been added to a line
             else:
-                self.node_line.append((node, i_n))
+                break
 
-        time.sleep(5)
+        # all nodes that are not self sufficient will go to the line (i think ordered list work good here)
+        self.node_line = self.graph[i_n:]
+
+        while self._nodes_check():
+            time.sleep(3)
+
+    def _nodes_check(self):
+        for to_node in self.node_line:
+
 
         while self.node_line:
             logger.debug("Submitter, node_line: {}".format(self.node_line))
-            for i, (node, i_n) in enumerate(self.node_line):
+            for i, node in enumerate(self.node_line):
                 for (out_node, out_var, inp) in node.needed_outputs:
                     # TODO this works only because there is no mapper!
                     try:
@@ -53,7 +61,7 @@ class Submiter(object):
                             node.inputs.update({inp: eval(f.readline())})
                         node.needed_outputs.remove((out_node, out_var, inp))
                 if not node.needed_outputs:
-                    self.node_line.remove((node, i_n))
+                    self.node_line.remove(node)
                     node.sufficient = True
                     self.submit_work(node)
             time.sleep(3)

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -56,7 +56,6 @@ class Submiter(object):
         for to_node in self.node_line:
             ready = True
             for (from_node, from_socket, to_socket) in to_node.needed_outputs:
-#                pdb.set_trace()
                 if from_node.global_done:
                     try:
                         self._to_finish.remove(from_node)
@@ -78,54 +77,9 @@ class Submiter(object):
         return self._to_finish
 
 
-        # final reading of the results, this will be removed in the final version (TODO)
-        # combining all results from specifics nodes together (for all state elements)
-        # for (i_n, node) in enumerate(self.graph):
-        #     for key_out in node._out_nm:
-        #         node._result[key_out] = []
-        #         if node._inputs:
-        #             files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
-        #             for file in files:
-        #                 st_el = file.split(os.sep)[-2].split("_")
-        #                 st_dict =  collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
-        #                                                         for el in st_el])
-        #                 with open(file) as fout:
-        #                     node._result[key_out].append((st_dict, eval(fout.readline())))
-        #         # for nodes without input
-        #         else:
-        #             files = [name for name in glob.glob("{}/{}.txt".format(node.nodedir, key_out))]
-        #             with open(files[0]) as fout:
-        #                 node._result[key_out].append(({}, eval(fout.readline())))
-
-
-
     def submit_work(self, node):
         node.node_states_inputs = State(state_inputs=node._inputs, mapper=node._mapper,
                                         inp_ord_map=node._input_order_map)
         for (i, ind) in enumerate(itertools.product(*node.node_states._all_elements)):
             logger.debug("SUBMIT WORKER, node: {}, ind: {}".format(node, ind))
             self.worker.run_el(node.run_interface_el, (i, ind))
-
-
-
-    # not beeing used now (probably will be removed)
-    # def _waiting_for_output(self):
-    #     # checking which node is ready to go. should be done my callback (TODO)
-    #     while self.node_line:
-    #         logger.debug("Submitter, node_line: {}".format(self.node_line))
-    #         for i, node in enumerate(self.node_line):
-    #             for (out_node, out_var, inp) in node.needed_outputs:
-    #                 # TODO this works only because there is no mapper!
-    #                 try:
-    #                     file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
-    #                 except(IndexError):
-    #                     file_output = None
-    #                 if file_output and os.path.isfile(file_output):
-    #                     with open(file_output) as f:
-    #                         node.inputs.update({inp: eval(f.readline())})
-    #                     node.needed_outputs.remove((out_node, out_var, inp))
-    #             if not node.needed_outputs:
-    #                 self.node_line.remove(node)
-    #                 node.sufficient = True
-    #                 self.submit_work(node)
-    #         time.sleep(3)

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -60,22 +60,22 @@ class Submiter(object):
 
         # final reading of the results, this will be removed in the final version (TODO)
         # combining all results from specifics nodes together (for all state elements)
-        for (i_n, node) in enumerate(self.graph):
-            for key_out in node._out_nm:
-                node._result[key_out] = []
-                if node._inputs:
-                    files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
-                    for file in files:
-                        st_el = file.split(os.sep)[-2].split("_")
-                        st_dict =  collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
-                                                                for el in st_el])
-                        with open(file) as fout:
-                            node._result[key_out].append((st_dict, eval(fout.readline())))
-                # for nodes without input
-                else:
-                    files = [name for name in glob.glob("{}/{}.txt".format(node.nodedir, key_out))]
-                    with open(files[0]) as fout:
-                        node._result[key_out].append(({}, eval(fout.readline())))
+        # for (i_n, node) in enumerate(self.graph):
+        #     for key_out in node._out_nm:
+        #         node._result[key_out] = []
+        #         if node._inputs:
+        #             files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
+        #             for file in files:
+        #                 st_el = file.split(os.sep)[-2].split("_")
+        #                 st_dict =  collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
+        #                                                         for el in st_el])
+        #                 with open(file) as fout:
+        #                     node._result[key_out].append((st_dict, eval(fout.readline())))
+        #         # for nodes without input
+        #         else:
+        #             files = [name for name in glob.glob("{}/{}.txt".format(node.nodedir, key_out))]
+        #             with open(files[0]) as fout:
+        #                 node._result[key_out].append(({}, eval(fout.readline())))
 
 
 

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -19,14 +19,10 @@ logger = logging.getLogger('workflow')
 class Submiter(object):
     def __init__(self, graph, plugin):
         self.graph = graph
-        # i only use it for callback (had problem when I was passing node
-        # instead of node.name - `self.node_line.remove(to_node)` gives an error)
-        self.graph_names = dict([(node.name, node) for node in self.graph])
         self.plugin = plugin
         self.node_line = []
-        self.done = queue.Queue()
         if self.plugin == "mp":
-            self.worker = MpWorker(done=self.done)
+            self.worker = MpWorker()
         logger.debug('Initialize Submitter, graph: {}'.format(graph))
         self._count_subm = 0
         self._count_done = 0
@@ -36,68 +32,34 @@ class Submiter(object):
         for (i_n, node) in enumerate(self.graph):
             # checking if a node has all input (doesnt have to wait for others)
             if node.sufficient:
-                self._count_subm += 1
                 self.submit_work(node)
             # if its not, its been added to a line
             else:
-                self.node_line.append(node)
+                self.node_line.append((node, i_n))
 
-        # TODO: should add an extra condition to not stay here forever
+        time.sleep(5)
+
         while self.node_line:
-            logger.debug("Submitter, node_line BEFORE trying to get new output: {}".format(self.node_line))
-            try:
-                el_done = self.done.get(timeout=1)
-                logger.debug("Submitter, el from self.done: {}".format(el_done))
-                self._count_done += 1
-                time.sleep(2)
-                self.connecting_output(el_done)
-            except queue.Empty:
-                time.sleep(3)
-            logger.debug("Submitter, node_line AFTER trying to get new output: {}".format(self.node_line))
+            logger.debug("Submitter, node_line: {}".format(self.node_line))
+            for i, (node, i_n) in enumerate(self.node_line):
+                for (out_node, out_var, inp) in node.needed_outputs:
+                    # TODO this works only because there is no mapper!
+                    try:
+                        file_output = [name for name in glob.glob("{}/*/{}.txt".format(out_node.nodedir, out_var))][0]
+                    except(IndexError):
+                        file_output = None
+                    if file_output and os.path.isfile(file_output):
+                        with open(file_output) as f:
+                            node.inputs.update({inp: eval(f.readline())})
+                        node.needed_outputs.remove((out_node, out_var, inp))
+                if not node.needed_outputs:
+                    self.node_line.remove((node, i_n))
+                    node.sufficient = True
+                    self.submit_work(node)
+            time.sleep(3)
 
-        self._collecting_results()
-
-
-    def connecting_output(self, el_out):
-        from_node = self.graph_names[el_out[2]]#el_out[2]
-        for (from_socket, to_node, to_socket) in from_node.sending_output:
-            if (from_node, from_socket, to_socket) in to_node.needed_outputs:
-                # TODO this works only because there is no mapper!
-                file_output = [name for name in glob.glob("{}/*/{}.txt".format(from_node.nodedir, from_socket))][0]
-                with open(file_output) as f:
-                    to_node.inputs.update({to_socket: eval(f.readline())})
-                to_node.needed_outputs.remove((from_node, from_socket, to_socket))
-
-                if not to_node.needed_outputs:
-                    self.node_line.remove(to_node)
-                    to_node.sufficient = True
-                    self._count_subm += 1
-                    self.submit_work(to_node)
-            else:
-                raise Exception("something wrong with connections")
-
-
-    def submit_work(self, node):
-        node.node_states_inputs = State(state_inputs=node._inputs, mapper=node._mapper,
-                                        inp_ord_map=node._input_order_map)
-        for (i, ind) in enumerate(itertools.product(*node.node_states._all_elements)):
-            logger.debug("SUBMIT WORKER, node: {}, ind: {}".format(node, ind))
-            self.worker.run_el(node.run_interface_el, (i, ind))
-
-
-    def _collecting_results(self):
-        """
-        final reading of the results, this will be removed in the final version (TODO)
-         combining all results from specifics nodes together (for all state elements)
-        """
-        # have to check if all results are ready
-        while self._count_done < self._count_subm:
-            try:
-                self.done.get(timeout=1)
-                self._count_done += 1
-            except queue.Empty:
-                time.sleep(3)
-
+        # final reading of the results, this will be removed in the final version (TODO)
+        # combining all results from specifics nodes together (for all state elements)
         for (i_n, node) in enumerate(self.graph):
             for key_out in node._out_nm:
                 node._result[key_out] = []
@@ -105,8 +67,8 @@ class Submiter(object):
                     files = [name for name in glob.glob("{}/*/{}.txt".format(node.nodedir, key_out))]
                     for file in files:
                         st_el = file.split(os.sep)[-2].split("_")
-                        st_dict = collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
-                                                           for el in st_el])
+                        st_dict =  collections.OrderedDict([(el.split(".")[0], eval(el.split(".")[1]))
+                                                                for el in st_el])
                         with open(file) as fout:
                             node._result[key_out].append((st_dict, eval(fout.readline())))
                 # for nodes without input
@@ -115,6 +77,14 @@ class Submiter(object):
                     with open(files[0]) as fout:
                         node._result[key_out].append(({}, eval(fout.readline())))
 
+
+
+    def submit_work(self, node):
+        node.node_states_inputs = State(state_inputs=node._inputs, mapper=node._mapper,
+                                        inp_ord_map=node._input_order_map)
+        for (i, ind) in enumerate(itertools.product(*node.node_states._all_elements)):
+            logger.debug("SUBMIT WORKER, node: {}, ind: {}".format(node, ind))
+            self.worker.run_el(node.run_interface_el, (i, ind))
 
 
 

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -45,6 +45,7 @@ class Submiter(object):
             logger.debug("Submitter, in while, node_line: {}".format(self.node_line))
             time.sleep(3)
 
+        # TODO(?): combining two while together
         # this part simply waiting for all "last nodes" to finish
         while self._output_check():
             logger.debug("Submitter, in while, to_finish: {}".format(self._to_finish))

--- a/nipype2/engine/submiter.py
+++ b/nipype2/engine/submiter.py
@@ -24,8 +24,6 @@ class Submiter(object):
         if self.plugin == "mp":
             self.worker = MpWorker()
         logger.debug('Initialize Submitter, graph: {}'.format(graph))
-        self._count_subm = 0
-        self._count_done = 0
         self._to_finish = list(self.graph)
 
     def run_workflow(self):
@@ -37,7 +35,8 @@ class Submiter(object):
             else:
                 break
 
-        # all nodes that are not self sufficient will go to the line (i think ordered list work good here)
+        # all nodes that are not self sufficient will go to the line
+        # (i think ordered list work well here, since it's more efficient to check within a specific order)
         self.node_line = self.graph[i_n:]
 
         # this parts submits nodes that are waiting to be run

--- a/nipype2/engine/tests/test_workflow_basic.py
+++ b/nipype2/engine/tests/test_workflow_basic.py
@@ -47,11 +47,11 @@ def test_workflow_basic_1():
     wf = Workflow(nodes=[nA, nB], name="workflow_1", workingdir="test_1")
     wf.run()
 
-    # assert nA.result["out"][0][0] == {"a":5}
-    # assert nA.result["out"][0][1] == 25
-    #
-    # assert nB.result["out"][0][0] == {"b": 15}
-    # assert nB.result["out"][0][1] == 17
+    assert nA.result["out"][0][0] == {"a":5}
+    assert nA.result["out"][0][1] == 25
+
+    assert nB.result["out"][0][0] == {"b": 15}
+    assert nB.result["out"][0][1] == 17
 
 
 def test_workflow_basic_2():
@@ -69,14 +69,14 @@ def test_workflow_basic_2():
     wf.connect(nA, "out", nC, "c")
     wf.run()
 
-    # assert nA.result["out"][0][0] == {"a":5}
-    # assert nA.result["out"][0][1] == 25
-    #
-    # assert nB.result["out"][0][0] == {"b": 15}
-    # assert nB.result["out"][0][1] == 17
-    #
-    # assert nC.result["out"][0][0] == {"a":5}
-    # assert nC.result["out"][0][1] == 250
+    assert nA.result["out"][0][0] == {"a":5}
+    assert nA.result["out"][0][1] == 25
+
+    assert nB.result["out"][0][0] == {"b": 15}
+    assert nB.result["out"][0][1] == 17
+
+    assert nC.result["out"][0][0] == {"a":5}
+    assert nC.result["out"][0][1] == 250
 
 
 def test_workflow_basic_3():
@@ -106,20 +106,20 @@ def test_workflow_basic_3():
     wf.connect(nD, "out", nE, "e2")
     wf.run()
 
-    # assert nA.result["out"][0][0] == {"a": 5}
-    # assert nA.result["out"][0][1] == 25
-    #
-    # assert nB.result["out"][0][0] == {"b": 15}
-    # assert nB.result["out"][0][1] == 17
-    #
-    # assert nC.result["out"][0][0] == {"a": 5}
-    # assert nC.result["out"][0][1] == 250
-    #
-    # assert nD.result["out"][0][0] == {"a": 5, "b": 15}
-    # assert nD.result["out"][0][1] == 42
-    #
-    # assert nE.result["out"][0][0] == {"a": 5, "b": 15}
-    # assert nE.result["out"][0][1] == 10500
-    #
-    # assert nF.result["out"][0][0] == {}
-    # assert nF.result["out"][0][1] == 0
+    assert nA.result["out"][0][0] == {"a": 5}
+    assert nA.result["out"][0][1] == 25
+
+    assert nB.result["out"][0][0] == {"b": 15}
+    assert nB.result["out"][0][1] == 17
+
+    assert nC.result["out"][0][0] == {"a": 5}
+    assert nC.result["out"][0][1] == 250
+
+    assert nD.result["out"][0][0] == {"a": 5, "b": 15}
+    assert nD.result["out"][0][1] == 42
+
+    assert nE.result["out"][0][0] == {"a": 5, "b": 15}
+    assert nE.result["out"][0][1] == 10500
+
+    assert nF.result["out"][0][0] == {}
+    assert nF.result["out"][0][1] == 0

--- a/nipype2/engine/tests/test_workflow_basic.py
+++ b/nipype2/engine/tests/test_workflow_basic.py
@@ -44,11 +44,11 @@ def test_workflow_basic_1():
     wf = Workflow(nodes=[nA, nB], name="workflow_1", workingdir="test_1")
     wf.run()
 
-    assert nA.result["out"][0][0] == {"a":5}
-    assert nA.result["out"][0][1] == 25
-
-    assert nB.result["out"][0][0] == {"b": 15}
-    assert nB.result["out"][0][1] == 17
+    # assert nA.result["out"][0][0] == {"a":5}
+    # assert nA.result["out"][0][1] == 25
+    #
+    # assert nB.result["out"][0][0] == {"b": 15}
+    # assert nB.result["out"][0][1] == 17
 
 
 def test_workflow_basic_2():
@@ -66,14 +66,14 @@ def test_workflow_basic_2():
     wf.connect(nA, "out", nC, "c")
     wf.run()
 
-    assert nA.result["out"][0][0] == {"a":5}
-    assert nA.result["out"][0][1] == 25
-
-    assert nB.result["out"][0][0] == {"b": 15}
-    assert nB.result["out"][0][1] == 17
-
-    assert nC.result["out"][0][0] == {"a":5}
-    assert nC.result["out"][0][1] == 250
+    # assert nA.result["out"][0][0] == {"a":5}
+    # assert nA.result["out"][0][1] == 25
+    #
+    # assert nB.result["out"][0][0] == {"b": 15}
+    # assert nB.result["out"][0][1] == 17
+    #
+    # assert nC.result["out"][0][0] == {"a":5}
+    # assert nC.result["out"][0][1] == 250
 
 
 def test_workflow_basic_3():
@@ -103,20 +103,20 @@ def test_workflow_basic_3():
     wf.connect(nD, "out", nE, "e2")
     wf.run()
 
-    assert nA.result["out"][0][0] == {"a": 5}
-    assert nA.result["out"][0][1] == 25
-
-    assert nB.result["out"][0][0] == {"b": 15}
-    assert nB.result["out"][0][1] == 17
-
-    assert nC.result["out"][0][0] == {"a": 5}
-    assert nC.result["out"][0][1] == 250
-
-    assert nD.result["out"][0][0] == {"a": 5, "b": 15}
-    assert nD.result["out"][0][1] == 42
-
-    assert nE.result["out"][0][0] == {"a": 5, "b": 15}
-    assert nE.result["out"][0][1] == 10500
-
-    assert nF.result["out"][0][0] == {}
-    assert nF.result["out"][0][1] == 0
+    # assert nA.result["out"][0][0] == {"a": 5}
+    # assert nA.result["out"][0][1] == 25
+    #
+    # assert nB.result["out"][0][0] == {"b": 15}
+    # assert nB.result["out"][0][1] == 17
+    #
+    # assert nC.result["out"][0][0] == {"a": 5}
+    # assert nC.result["out"][0][1] == 250
+    #
+    # assert nD.result["out"][0][0] == {"a": 5, "b": 15}
+    # assert nD.result["out"][0][1] == 42
+    #
+    # assert nE.result["out"][0][0] == {"a": 5, "b": 15}
+    # assert nE.result["out"][0][1] == 10500
+    #
+    # assert nF.result["out"][0][0] == {}
+    # assert nF.result["out"][0][1] == 0

--- a/nipype2/engine/tests/test_workflow_basic.py
+++ b/nipype2/engine/tests/test_workflow_basic.py
@@ -26,6 +26,9 @@ def funD(d1, d2):
     return d1 + d2
 
 def funE(e1, e2):
+    print("E Before Waiting")
+    time.sleep(10)
+    print("E After Waiting")
     return e1 * e2
 
 def funF():

--- a/nipype2/engine/workers.py
+++ b/nipype2/engine/workers.py
@@ -16,15 +16,13 @@ logger = logging.getLogger('workflow')
 
 
 class MpWorker(object):
-    def __init__(self, done, nr_proc=4): #should be none
+    def __init__(self, nr_proc=4): #should be none
         self.nr_proc = nr_proc
-        self.done = done
         self.pool = mp.Pool(processes=self.nr_proc)
         logger.debug('Initialize Worker')
 
 
     def run_el(self, interface, inp):
-        # dj NOTE: if I return (inp, node) as callback, then i have it right away (before node ends)
-        self.pool.apply_async(interface, (inp[0], inp[1]), callback=self.done.put)
+        self.pool.apply_async(interface, (inp[0], inp[1]))
 
 


### PR DESCRIPTION
@satra - changes we were talking during our meeting (I came back to the version before mapper for now)

- removing callback
- changing `Submitter.run_worflow` and while logic
- collecting input from previous node has been moved to `Node.run_interface_el` and it's collected just before running an interface fo a single element
- collecting results for a node has been moved to `Node` (`result` property)